### PR TITLE
Range and For loop

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -103,6 +103,19 @@ impl Interpreter {
         }
     }
 
+    fn check_integer_operand(&mut self, operator: &Token, left: &Literals, right: &Literals) -> Result<()> {
+        match (left, right) {
+            (Literals::Number(l), Literals::Number(r)) => {
+                if l.fract() == 0.0 && r.fract() == 0.0 {
+                    return Ok(());
+                }
+            },
+            _ => {}
+        }
+        self.report_err(operator.clone(), format!("Operands of '{}' must be two integers.", operator.lexeme));
+        Err(Interrupt::Error)
+    }
+
     fn report_err(&mut self, token: Token, message: String) {
         let rt_err = RuntimeError::new(token.clone(), message);
         self.error_handler.runtime_error(rt_err);
@@ -264,6 +277,44 @@ impl ExprVisitor for Interpreter {
                             }
                         }
                     },
+                    TokenType::DOT_DOT => {
+                        match self.check_integer_operand(operator, &left_val, &right_val) {
+                            Ok(_) => {
+                                let (left, right) = (left_val.clone().unwrap_number().unwrap() as isize,
+                                                                 right_val.clone().unwrap_number().unwrap() as isize);
+                                let is_right_bigger = right >= left;
+                                let diff = (right - left).abs();
+
+                                let mut res = Vec::new();
+                                for i in 0..diff {
+                                    let new = left + i * if is_right_bigger { 1 } else { -1 };
+                                    res.push(Literals::Number(new as f64));
+                                }
+
+                                Ok(Literals::Tuple(Box::new(res)))
+                            },
+                            Err(_) => Err(Interrupt::Error)
+                        }
+                    },
+                    TokenType::DOT_DOT_DOT => {
+                        match self.check_integer_operand(operator, &left_val, &right_val) {
+                            Ok(_) => {
+                                let (left, right) = (left_val.clone().unwrap_number().unwrap() as isize,
+                                                     right_val.clone().unwrap_number().unwrap() as isize);
+                                let is_right_bigger = right >= left;
+                                let diff = (right - left).abs();
+
+                                let mut res = Vec::new();
+                                for i in 0..(diff + 1) {
+                                    let new = left + i * if is_right_bigger { 1 } else { -1 };
+                                    res.push(Literals::Number(new as f64));
+                                }
+
+                                Ok(Literals::Tuple(Box::new(res)))
+                            },
+                            Err(_) => Err(Interrupt::Error)
+                        }
+                    }
                     _ => {
                         self.report_err(operator.clone(),
                                         format!("Unsupported operator: '{}'.", operator.lexeme));
@@ -748,7 +799,6 @@ impl StmtVisitor for Interpreter {
                 Ok(())
             },
 
-            // TODO: Holy shit, clean this up later.
             Stmt::For(var_name, range_name, body) => {
                 let range_vals = self.evaluate(range_name)?;
                 let arr = match range_vals {

--- a/test.dove
+++ b/test.dove
@@ -1,20 +1,3 @@
-fun create_multiplier(scale) {
-    return lambda x -> {
-        let res = 0
-
-        let i = 0
-        while i < scale {
-            res = res + x
-            i = i + 1
-        }
-
-        return res
-    }
+for i in 0..10 {
+    print i
 }
-
-let doubler = create_multiplier(2)
-let tripler = create_multiplier(3)
-
-print doubler(3)
-print tripler(2)
-print tripler(doubler(2))


### PR DESCRIPTION
Evaluate binary expressions with range (`..`/`...`) operators to tuples;
Fix issue where `For` loops cannot iterate over tuples.

Closes #22 